### PR TITLE
Update bash prompt for SHLVL 2 and tmux session

### DIFF
--- a/home/.config/bash/bashrc.d/12-bash-prompt
+++ b/home/.config/bash/bashrc.d/12-bash-prompt
@@ -123,7 +123,7 @@ _e2_update_prompt() {
 		PS1+="\[${YELLOW}\] [AWS ${aws_text}]"
 	fi
 
-	if [[ "${SHLVL}" -gt 1 ]]; then
+	if (( SHLVL > 1 )) && ! [[ -n "${TMUX-}" && "${SHLVL}" -le 2 ]] ; then
 		PS1+="\[${YELLOW229}\] ${TERMINAL_GLYPH} ${SHLVL}"
 	fi
 


### PR DESCRIPTION
Do not show shell level section in prompt when shell level = 2 and in a tmux session. Basically force tmux shell level section to start at 3.